### PR TITLE
fix escape function call

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -516,7 +516,7 @@ class Server
         $log['time'] = time();
         $log['type'] = empty($msg['type']) ? '' : $msg['type'];
 
-        $_msg = $this->db->escape(json_encode($msg));
+        $_msg = Filter::escape(json_encode($msg));
         $_type = empty($msg['type']) ? '' : $msg['type'];
 
         $sql = "insert into ".self::PREFIX."_history(


### PR DESCRIPTION
src/Server.php的line519原来为 $this->db->escape(json_encode($msg));
client发消息后 ，server报错：Fatal error: Uncaught Error: Call to undefined method Swoole\Coroutine\MySQL::escape() in webim/src/Pool.php:48

改为 $_msg = Filter::escape(json_encode($msg));后程序执行正常。  
烦请看一下修改是否正确。  




